### PR TITLE
Fix trunk and frunk open calls

### DIFF
--- a/src/tesla.html
+++ b/src/tesla.html
@@ -86,6 +86,7 @@
             <option value="navigationRequest">navigationRequest</option>
             <option value="nearbyChargers">nearbyChargers</option>
             <option value="openChargePort">openChargePort</option>
+            <option value="openFrunk">openTrunk</option>
             <option value="openTrunk">openTrunk</option>
             <option value="remoteStart">remoteStart</option>
             <option value="resetValetPin">resetValetPin</option>

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -88,7 +88,8 @@ module.exports = function (RED) {
             case 'navigationRequest': return tjs.navigationRequestAsync({authToken, vehicleID}, commandArgs.subject, commandArgs.text, commandArgs.locale);
             case 'nearbyChargers': return tjs.nearbyChargersAsync({authToken, vehicleID});
             case 'openChargePort': return tjs.openChargePortAsync({authToken, vehicleID});
-            case 'openTrunk': return tjs.openTrunkAsync({authToken, vehicleID});
+            case 'openFrunk': return tjs.openTrunkAsync({authToken, vehicleID}, "frunk");
+            case 'openTrunk': return tjs.openTrunkAsync({authToken, vehicleID}, "trunk");
             case 'remoteStart': return tjs.remoteStartAsync({authToken, vehicleID}, commandArgs.password);
             case 'resetValetPin': return tjs.resetValetPinAsync({authToken, vehicleID});
             case 'scheduleSoftwareUpdate': return tjs.scheduleSoftwareUpdateAsync({authToken, vehicleID}, commandArgs.offset);


### PR DESCRIPTION
The openTrunkAsync call in TeslaJs takes a second parameter, which determines whether the trunk or the frunk will be opened. That parameter was missing. This change adds the parameter, and adds a new method to open the frunk.
See https://github.com/mseminatore/TeslaJS/blob/414d850492dc93b280f12a96da29f4ecf4e1493e/docs/DOCS.md#openTrunkAsync

I don't really know how to test this locally. I know the method is not working in the latest release, and I think this will fix it, but I haven't confirmed that.