### PR TITLE
Fix frunk/trunk opening

### DIFF
--- a/src/tesla.js
+++ b/src/tesla.js
@@ -139,9 +139,9 @@ module.exports = function (RED) {
             case 'openChargePort':
                 return tjs.openChargePortAsync({authToken, vehicleID});
             case 'openFrunk':
-                return tjs.openTrunkAsync({authToken, vehicleID}, "frunk");
+                return tjs.openTrunkAsync({authToken, vehicleID}, "front");
             case 'openTrunk':
-                return tjs.openTrunkAsync({authToken, vehicleID}, "trunk");
+                return tjs.openTrunkAsync({authToken, vehicleID}, "rear");
             case 'remoteStart':
                 return tjs.remoteStartAsync({authToken, vehicleID}, commandArgs.password);
             case 'resetValetPin':


### PR DESCRIPTION
This fixes the calls for openFunk and openTrunk.

I think there was some confusion from the TeslaJS docs; for [openTrunk](https://github.com/mseminatore/TeslaJS/blob/master/docs/DOCS.md#opentrunkoptions-which-callback--object) it says to pass a [FRUNK](https://github.com/mseminatore/TeslaJS/blob/master/docs/DOCS.md#FRUNK) or [TRUNK](https://github.com/mseminatore/TeslaJS/blob/master/docs/DOCS.md#trunk) constant (set to 'front' and 'rear' respectively), but [openTrunkAsync](https://github.com/mseminatore/TeslaJS/blob/master/docs/DOCS.md#opentrunkasyncoptions-which--promise) says to pass a string of "trunk" or "frunk" - I think they just messed that part up.

I've tested this with "front" and "rear" and confirmed they are working.