### PR TITLE
Update APIs to follow future teslajs library with Low Level Tesla API calls

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Node red nodes for controlling and communicating with Tesla devices, like the Model 3 and Model S electric cars. Based on the [TeslaJS](https://github.com/mseminatore/TeslaJS) library.
 
 ## How to install:
-Run `npm install node-red-contrib-tesla --save` or just install it from the Node-red dashboard (manage palette).
+Run `npm install @gaphi/node-red-contrib-tesla --save` or just install it from the Node-red dashboard (manage palette).
 
 ## How to use:
 This package only has one node (and one configuration node). You don't have to worry about auth tokens, it will be handled automatically. 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Node red nodes for controlling and communicating with Tesla devices, like the Mo
 ## How to install:
 Run `npm install @gaphi/node-red-contrib-tesla --save` or just install it from the Node-red dashboard (manage palette).
 
-## 2.0 updates:
+## 2.0.0 updates:
 I made a lot of changes in this update:
 - new auth flow (email and refresh token). The teslaJS library is no longer used to fetch the token, but it is still used for all other commands. Therefor, the newer commands (like setting the charging amps) are not supported just yet. Just be patient a bit longer, i will add them in time.
 - Autowakeup is now a setting (it was always enabled, now you can choose). It's also overwritable by setting `msg.autoWakeUp`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,19 @@
 {
   "name": "node-red-contrib-tesla",
-  "version": "2.0.0",
+  "version": "2.0.1-7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@gaphi/teslajs": {
+      "version": "4.11.0-5",
+      "resolved": "https://registry.npmjs.org/@gaphi/teslajs/-/teslajs-4.11.0-5.tgz",
+      "integrity": "sha512-b2bQYNNO1qkj4L27UBvSsLnc2FJK5XaHPtAmTrb0kz/brhKqVHslJwumZ5nbUalfmJoxMfEllDTJWjJQEFechA==",
+      "requires": {
+        "promise": "^8.0.3",
+        "request": "^2.88.2",
+        "ws": "^8.0.0"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -18,12 +28,12 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -31,7 +41,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -41,25 +51,39 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
     },
     "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -67,7 +91,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -80,12 +104,12 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -98,7 +122,7 @@
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -112,7 +136,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -125,14 +149,14 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
     },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
     },
     "form-data": {
       "version": "2.3.3",
@@ -147,7 +171,7 @@
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -155,7 +179,7 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
     },
     "har-validator": {
       "version": "5.1.5",
@@ -169,7 +193,7 @@
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -179,17 +203,22 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -199,7 +228,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "jsprim": {
       "version": "1.4.2",
@@ -210,13 +239,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
-      },
-      "dependencies": {
-        "json-schema": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-        }
       }
     },
     "mime-db": {
@@ -240,25 +262,30 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "promise": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "requires": {
         "asap": "~2.0.6"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "qs": {
       "version": "6.5.3",
@@ -303,9 +330,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -316,16 +343,6 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
-      }
-    },
-    "teslajs": {
-      "version": "4.9.11",
-      "resolved": "https://registry.npmjs.org/teslajs/-/teslajs-4.9.11.tgz",
-      "integrity": "sha512-vir28xLhNwqTTs1EioFPhnwMVKFdTdbaDI3sPuJ6iApW5A4951Whx+jznuoiyzWLRwCqQ2m/j/YvXj9H90zaZQ==",
-      "requires": {
-        "promise": "^8.0.3",
-        "request": "^2.88.2",
-        "ws": "^7.5.0"
       }
     },
     "tough-cookie": {
@@ -340,7 +357,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -348,7 +365,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -366,7 +383,7 @@
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -374,9 +391,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,302 +1,371 @@
 {
-  "name": "node-red-contrib-tesla",
-  "version": "2.0.1-7",
-  "lockfileVersion": 1,
+  "name": "@gaphi/node-red-contrib-tesla",
+  "version": "2.0.1-8",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@gaphi/teslajs": {
-      "version": "4.11.0-5",
-      "resolved": "https://registry.npmjs.org/@gaphi/teslajs/-/teslajs-4.11.0-5.tgz",
-      "integrity": "sha512-b2bQYNNO1qkj4L27UBvSsLnc2FJK5XaHPtAmTrb0kz/brhKqVHslJwumZ5nbUalfmJoxMfEllDTJWjJQEFechA==",
-      "requires": {
+  "packages": {
+    "": {
+      "name": "@gaphi/node-red-contrib-tesla",
+      "version": "2.0.1-8",
+      "license": "MIT",
+      "dependencies": {
+        "@gaphi/teslajs": "^4.11.0-1",
+        "axios": "^1.6.2"
+      }
+    },
+    "node_modules/@gaphi/teslajs": {
+      "version": "4.11.0-6",
+      "resolved": "https://registry.npmjs.org/@gaphi/teslajs/-/teslajs-4.11.0-6.tgz",
+      "integrity": "sha512-Co4Rm9LVFOmpIs+fyZGUwDfFv3CivPABoFs9YBnJOxAEl7PhkedMw6vkcg7CHUYDv9WM9pyoQXTKF0v3lj6osQ==",
+      "dependencies": {
         "promise": "^8.0.3",
         "request": "^2.88.2",
         "ws": "^8.0.0"
       }
     },
-    "ajv": {
+    "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "requires": {
+      "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "asap": {
+    "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "asn1": {
+    "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "requires": {
+      "dependencies": {
         "safer-buffer": "~2.1.0"
       }
     },
-    "assert-plus": {
+    "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
-    "asynckit": {
+    "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
-    "aws-sign2": {
+    "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "engines": {
+        "node": "*"
+      }
     },
-    "aws4": {
+    "node_modules/aws4": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
-    "axios": {
+    "node_modules/axios": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
       "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
-      "requires": {
+      "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
-    "bcrypt-pbkdf": {
+    "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "requires": {
+      "dependencies": {
         "tweetnacl": "^0.14.3"
       }
     },
-    "caseless": {
+    "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
-    "combined-stream": {
+    "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
+      "dependencies": {
         "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "core-util-is": {
+    "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
-    "dashdash": {
+    "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "requires": {
+      "dependencies": {
         "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
-    "delayed-stream": {
+    "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "ecc-jsbn": {
+    "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "requires": {
+      "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
     },
-    "extend": {
+    "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
-    "extsprintf": {
+    "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ]
     },
-    "fast-deep-equal": {
+    "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
-    "fast-json-stable-stringify": {
+    "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
-    "follow-redirects": {
+    "node_modules/follow-redirects": {
       "version": "1.15.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
-    "getpass": {
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "requires": {
+      "dependencies": {
         "assert-plus": "^1.0.0"
       }
     },
-    "har-schema": {
+    "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "har-validator": {
+    "node_modules/har-validator": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "requires": {
+      "deprecated": "this library is no longer supported",
+      "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "http-signature": {
+    "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "requires": {
+      "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
-    "is-typedarray": {
+    "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
-    "isstream": {
+    "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
-    "jsbn": {
+    "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
-    "json-schema": {
+    "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
-    "json-schema-traverse": {
+    "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
-    "json-stringify-safe": {
+    "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
-    "jsprim": {
+    "node_modules/jsprim": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "requires": {
+      "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
-    "mime-db": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
-    },
-    "mime-types": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
-      "requires": {
-        "mime-db": "1.49.0"
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "oauth-sign": {
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "engines": {
+        "node": "*"
+      }
     },
-    "performance-now": {
+    "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
-    "promise": {
+    "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
       "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
-      "requires": {
+      "dependencies": {
         "asap": "~2.0.6"
       }
     },
-    "proxy-from-env": {
+    "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-    "psl": {
+    "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
-    "punycode": {
+    "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "qs": {
+    "node_modules/qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
-    "request": {
+    "node_modules/request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
         "caseless": "~0.12.0",
@@ -317,23 +386,53 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "safe-buffer": {
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
-    "safer-buffer": {
+    "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "sshpk": {
+    "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
       "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "requires": {
+      "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
         "bcrypt-pbkdf": "^1.0.0",
@@ -343,57 +442,93 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "tough-cookie": {
+    "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
+      "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
-    "tunnel-agent": {
+    "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "requires": {
+      "dependencies": {
         "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "tweetnacl": {
+    "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
-    "uri-js": {
+    "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "requires": {
+      "dependencies": {
         "punycode": "^2.1.0"
       }
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
-    "verror": {
+    "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "requires": {
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
     },
-    "ws": {
+    "node_modules/ws": {
       "version": "8.14.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gaphi/node-red-contrib-tesla",
-  "version": "2.0.1-8",
+  "version": "2.0.1-9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gaphi/node-red-contrib-tesla",
-      "version": "2.0.1-8",
+      "version": "2.0.1-9",
       "license": "MIT",
       "dependencies": {
         "@gaphi/teslajs": "^4.11.0-1",

--- a/package.json
+++ b/package.json
@@ -67,5 +67,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "2.0.1-8"
+  "version": "2.0.1-9"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "_from": "@gaphi/node-red-contrib-tesla@1.0.6-5",
-  "_id": "@gaphi/node-red-contrib-tesla@1.0.6-5",
+  "_from": "@gaphi/node-red-contrib-tesla@1.0.6-6",
   "_inBundle": false,
   "_integrity": "sha512-+/wyoeXS38BqAWCbhmKjEdlklXxglXXxW9VcaZdsORbtaYuhOSJdX5GoDTHJEuBmml/ff4VEhFHKCfJH5TqlEg==",
   "_location": "/@gaphi/node-red-contrib-tesla",
@@ -8,21 +7,21 @@
   "_requested": {
     "type": "version",
     "registry": true,
-    "raw": "@gaphi/node-red-contrib-tesla@1.0.6-5",
+    "raw": "@gaphi/node-red-contrib-tesla@1.0.6-6",
     "name": "@gaphi/node-red-contrib-tesla",
     "escapedName": "@gaphi%2fnode-red-contrib-tesla",
     "scope": "@gaphi",
-    "rawSpec": "1.0.6-5",
+    "rawSpec": "1.0.6-6",
     "saveSpec": null,
-    "fetchSpec": "1.0.6-5"
+    "fetchSpec": "1.0.6-6"
   },
   "_requiredBy": [
     "#USER",
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/@gaphi/node-red-contrib-tesla/-/node-red-contrib-tesla-1.0.6-5.tgz",
+  "_resolved": "https://registry.npmjs.org/@gaphi/node-red-contrib-tesla/-/node-red-contrib-tesla-1.0.6-6.tgz",
   "_shasum": "3608838f1a386da22f6fe112a83d5bbcd2fcaee9",
-  "_spec": "@gaphi/node-red-contrib-tesla@1.0.6-5",
+  "_spec": "@gaphi/node-red-contrib-tesla@1.0.6-6",
   "_where": "/data",
   "author": {
     "name": "Philippe Gresse-Lugue"
@@ -30,9 +29,9 @@
   "bugs": {
     "url": "https://github.com/GaPhi/node-red-contrib-tesla/issues"
   },
-  "bundleDependencies": false,
+  "bundleDependencies": [],
   "dependencies": {
-    "@gaphi/teslajs": ">=4.9.12-0"
+    "@gaphi/teslajs": "^4.9.12-0"
   },
   "deprecated": false,
   "description": "Node red module to control Tesla vehicles and devices",
@@ -56,5 +55,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "1.0.6-5"
+  "version": "1.0.6-7"
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/GaPhi/node-red-contrib-tesla/issues"
   },
   "dependencies": {
-    "@gaphi/teslajs": "^4.9.12"
+    "@gaphi/teslajs": ">=4.9.12-0"
   },
   "deprecated": false,
   "description": "Node red module to control Tesla vehicles and devices",
@@ -48,5 +48,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "1.0.6-2"
+  "version": "1.0.6-4"
 }

--- a/package.json
+++ b/package.json
@@ -62,5 +62,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "2.0.1-5"
+  "version": "2.0.1-6"
 }

--- a/package.json
+++ b/package.json
@@ -62,5 +62,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "2.0.1-6"
+  "version": "2.0.1-7"
 }

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "bugs": {
     "url": "https://github.com/GaPhi/node-red-contrib-tesla/issues"
   },
-  "bundleDependencies": [],
+  "bundleDependencies": false,
   "contributors": [
     {
       "name": "Philippe Gresse-Lugue"
     }
   ],
   "dependencies": {
-    "axios": "^0.24.0",
-    "@gaphi/teslajs": "^4.9.12-2"
+    "@gaphi/teslajs": "^4.9.12-2",
+    "axios": "^0.24.0"
   },
   "deprecated": false,
   "description": "Node red module to control Tesla vehicles and devices",
@@ -37,5 +37,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "2.0.1-0",
+  "version": "2.0.1-1"
 }

--- a/package.json
+++ b/package.json
@@ -1,28 +1,36 @@
 {
-  "_from": "github:GaPhi/node-red-contrib-tesla",
+  "_from": "@gaphi/node-red-contrib-tesla@1.0.6-5",
+  "_id": "@gaphi/node-red-contrib-tesla@1.0.6-5",
   "_inBundle": false,
-  "_integrity": "",
-  "_location": "/node-red-contrib-tesla",
+  "_integrity": "sha512-+/wyoeXS38BqAWCbhmKjEdlklXxglXXxW9VcaZdsORbtaYuhOSJdX5GoDTHJEuBmml/ff4VEhFHKCfJH5TqlEg==",
+  "_location": "/@gaphi/node-red-contrib-tesla",
   "_phantomChildren": {},
   "_requested": {
-    "type": "git",
-    "raw": "GaPhi/node-red-contrib-tesla",
-    "rawSpec": "GaPhi/node-red-contrib-tesla",
-    "saveSpec": "github:GaPhi/node-red-contrib-tesla",
-    "fetchSpec": null,
-    "gitCommittish": null
+    "type": "version",
+    "registry": true,
+    "raw": "@gaphi/node-red-contrib-tesla@1.0.6-5",
+    "name": "@gaphi/node-red-contrib-tesla",
+    "escapedName": "@gaphi%2fnode-red-contrib-tesla",
+    "scope": "@gaphi",
+    "rawSpec": "1.0.6-5",
+    "saveSpec": null,
+    "fetchSpec": "1.0.6-5"
   },
   "_requiredBy": [
     "#USER",
     "/"
   ],
-  "_resolved": "github:GaPhi/node-red-contrib-tesla#31a4ce0a2d68e8714259b4cb2719956aec0e1b02",
-  "_spec": "GaPhi/node-red-contrib-tesla",
-  "_where": "/data/node_modules",
-  "author": "Philippe Gresse-Lugue",
+  "_resolved": "https://registry.npmjs.org/@gaphi/node-red-contrib-tesla/-/node-red-contrib-tesla-1.0.6-5.tgz",
+  "_shasum": "3608838f1a386da22f6fe112a83d5bbcd2fcaee9",
+  "_spec": "@gaphi/node-red-contrib-tesla@1.0.6-5",
+  "_where": "/data",
+  "author": {
+    "name": "Philippe Gresse-Lugue"
+  },
   "bugs": {
     "url": "https://github.com/GaPhi/node-red-contrib-tesla/issues"
   },
+  "bundleDependencies": false,
   "dependencies": {
     "@gaphi/teslajs": ">=4.9.12-0"
   },
@@ -48,5 +56,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "1.0.6-4"
+  "version": "1.0.6-5"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
+  "_args": [
+    [
+      "@gaphi/node-red-contrib-tesla@2.0.1-7",
+      "/data"
+    ]
+  ],
   "_from": "@gaphi/node-red-contrib-tesla",
-  "_id": "@gaphi/node-red-contrib-tesla@2.0.1-3",
   "_inBundle": false,
   "_integrity": "sha512-ka5lJG7vt6nEWWUKdAQxEce+cnjb58aqrmS/dSP0HRmqheJz4Ii1MpKuHxWwojg+i6fcBorqZl/ngQXt9UGbNQ==",
   "_location": "/@gaphi/node-red-contrib-tesla",
@@ -20,7 +25,7 @@
     "#USER",
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/@gaphi/node-red-contrib-tesla/-/node-red-contrib-tesla-2.0.1-3.tgz",
+  "_resolved": "https://registry.npmjs.org/@gaphi/node-red-contrib-tesla/-/node-red-contrib-tesla-2.0.1-7.tgz",
   "_shasum": "27d02648124b1680a394e48dce7ccbae1328a42f",
   "_spec": "@gaphi/node-red-contrib-tesla",
   "_where": "/data",
@@ -62,5 +67,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "2.0.1-7"
+  "version": "2.0.1-8"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   ],
   "dependencies": {
-    "@gaphi/teslajs": "^4.9.12-2",
+    "@gaphi/teslajs": "^4.9.12-4",
     "axios": "^0.24.0"
   },
   "deprecated": false,
@@ -37,5 +37,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "2.0.1-1"
+  "version": "2.0.1-2"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   ],
   "dependencies": {
-    "@gaphi/teslajs": "^4.9.12-4",
+    "@gaphi/teslajs": "^4.10.1-1",
     "axios": "^0.24.0"
   },
   "deprecated": false,
@@ -37,5 +37,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "2.0.1-2"
+  "version": "2.0.1-3"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/GaPhi/node-red-contrib-tesla/issues"
   },
-  "bundleDependencies": false,
+  "bundleDependencies": [],
   "contributors": [
     {
       "name": "Philippe Gresse-Lugue"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@gaphi/teslajs": "^4.11.0-1",
-    "axios": "^0.24.0"
+    "axios": "^1.6.2"
   },
   "deprecated": false,
   "description": "Node red module to control Tesla vehicles and devices",

--- a/package.json
+++ b/package.json
@@ -67,5 +67,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "2.0.1-9"
+  "version": "2.0.1-10"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   ],
   "dependencies": {
-    "@gaphi/teslajs": "^4.10.1-1",
+    "@gaphi/teslajs": "^4.10.1-2",
     "axios": "^0.24.0"
   },
   "deprecated": false,
@@ -37,5 +37,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "2.0.1-3"
+  "version": "2.0.1-4"
 }

--- a/package.json
+++ b/package.json
@@ -1,18 +1,43 @@
 {
+  "_from": "@gaphi/node-red-contrib-tesla",
+  "_id": "@gaphi/node-red-contrib-tesla@2.0.1-3",
+  "_inBundle": false,
+  "_integrity": "sha512-ka5lJG7vt6nEWWUKdAQxEce+cnjb58aqrmS/dSP0HRmqheJz4Ii1MpKuHxWwojg+i6fcBorqZl/ngQXt9UGbNQ==",
+  "_location": "/@gaphi/node-red-contrib-tesla",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "@gaphi/node-red-contrib-tesla",
+    "name": "@gaphi/node-red-contrib-tesla",
+    "escapedName": "@gaphi%2fnode-red-contrib-tesla",
+    "scope": "@gaphi",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/@gaphi/node-red-contrib-tesla/-/node-red-contrib-tesla-2.0.1-3.tgz",
+  "_shasum": "27d02648124b1680a394e48dce7ccbae1328a42f",
+  "_spec": "@gaphi/node-red-contrib-tesla",
+  "_where": "/data",
   "author": {
     "name": "Martin Schimmel"
   },
   "bugs": {
     "url": "https://github.com/GaPhi/node-red-contrib-tesla/issues"
   },
-  "bundleDependencies": [],
+  "bundleDependencies": false,
   "contributors": [
     {
       "name": "Philippe Gresse-Lugue"
     }
   ],
   "dependencies": {
-    "@gaphi/teslajs": "^4.10.1-2",
+    "@gaphi/teslajs": "^4.11.0-1",
     "axios": "^0.24.0"
   },
   "deprecated": false,
@@ -37,5 +62,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "2.0.1-4"
+  "version": "2.0.1-5"
 }

--- a/package.json
+++ b/package.json
@@ -1,24 +1,52 @@
 {
-  "name": "node-red-contrib-tesla",
-  "version": "1.0.5",
+  "_from": "github:GaPhi/node-red-contrib-tesla",
+  "_inBundle": false,
+  "_integrity": "",
+  "_location": "/node-red-contrib-tesla",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "git",
+    "raw": "GaPhi/node-red-contrib-tesla",
+    "rawSpec": "GaPhi/node-red-contrib-tesla",
+    "saveSpec": "github:GaPhi/node-red-contrib-tesla",
+    "fetchSpec": null,
+    "gitCommittish": null
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "github:GaPhi/node-red-contrib-tesla#31a4ce0a2d68e8714259b4cb2719956aec0e1b02",
+  "_spec": "GaPhi/node-red-contrib-tesla",
+  "_where": "/data/node_modules",
+  "author": "Philippe Gresse-Lugue",
+  "bugs": {
+    "url": "https://github.com/GaPhi/node-red-contrib-tesla/issues"
+  },
+  "dependencies": {
+    "@gaphi/teslajs": "^4.9.12"
+  },
+  "deprecated": false,
   "description": "Node red module to control Tesla vehicles and devices",
+  "homepage": "https://github.com/GaPhi/node-red-contrib-tesla#readme",
   "keywords": [
     "node-red",
     "tesla"
   ],
-  "main": "src/tesla.js.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "Martin Schimmel",
   "license": "MIT",
+  "main": "src/tesla.js.js",
+  "name": "@gaphi/node-red-contrib-tesla",
   "node-red": {
     "nodes": {
       "tesla": "src/tesla.js"
     }
   },
-  "dependencies": {
-    "teslajs": "^4.9.11"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GaPhi/node-red-contrib-tesla.git"
   },
-  "repository": "https://github.com/onokje/node-red-contrib-tesla"
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "version": "1.0.6-2"
 }

--- a/package.json
+++ b/package.json
@@ -24,14 +24,19 @@
   "_spec": "@gaphi/node-red-contrib-tesla@1.0.6-6",
   "_where": "/data",
   "author": {
-    "name": "Philippe Gresse-Lugue"
+    "name": "Martin Schimmel"
   },
+  "contributors": [
+    {
+      "name": "Philippe Gresse-Lugue"
+    }
+  ],
   "bugs": {
     "url": "https://github.com/GaPhi/node-red-contrib-tesla/issues"
   },
   "bundleDependencies": [],
   "dependencies": {
-    "@gaphi/teslajs": "^4.9.12-0"
+    "@gaphi/teslajs": "^4.9.12-2"
   },
   "deprecated": false,
   "description": "Node red module to control Tesla vehicles and devices",
@@ -55,5 +60,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "1.0.6-7"
+  "version": "1.0.6-9"
 }

--- a/src/tesla.html
+++ b/src/tesla.html
@@ -118,7 +118,6 @@
             <option value="doorUnlock">doorUnlock</option>
             <option value="climateStart">climateStart</option>
             <option value="climateStop">climateStop</option>
-            <option value="closeChargePort">closeChargePort</option>
             <option value="flashLights">flashLights</option>
             <option value="honkHorn">honkHorn</option>
             <option value="maxDefrost">maxDefrost</option>
@@ -133,6 +132,7 @@
             <option value="navigationRequest">navigationRequest</option>
             <option value="nearbyChargers">nearbyChargers</option>
             <option value="openChargePort">openChargePort</option>
+            <option value="closeChargePort">closeChargePort</option>
             <option value="openFrunk">openFrunk</option>
             <option value="openTrunk">openTrunk</option>
             <option value="remoteStart">remoteStart</option>
@@ -323,11 +323,6 @@
             <td></td>
         </tr>
         <tr>
-            <td>closeChargePort</td>
-            <td>closeChargePort</td>
-            <td></td>
-        </tr>
-        <tr>
             <td>flashLights</td>
             <td>flashLights</td>
             <td></td>
@@ -395,6 +390,11 @@
         <tr>
             <td>openChargePort</td>
             <td>openChargePort</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>closeChargePort</td>
+            <td>closeChargePort</td>
             <td></td>
         </tr>
         <tr>

--- a/src/tesla.html
+++ b/src/tesla.html
@@ -160,7 +160,7 @@
             <tr><td>climateStop</td><td>climateStop</td><td></td></tr>
             <tr><td>flashLights</td><td>flashLights</td><td></td></tr>
             <tr><td>honkHorn</td><td>honkHorn</td><td></td></tr>
-            <tr><td>maxDefrost</td><td>maxDefrost</td><td></td></tr>
+            <tr><td>maxDefrost</td><td>maxDefrost</td><td>onoff</td></tr>
             <tr><td>mediaTogglePlayback</td><td>mediaTogglePlayback</td><td></td></tr>
             <tr><td>mediaPlayNext</td><td>mediaPlayNext</td><td></td></tr>
             <tr><td>mediaPlayPrevious</td><td>mediaPlayPrevious</td><td></td></tr>

--- a/src/tesla.html
+++ b/src/tesla.html
@@ -231,7 +231,7 @@
         <tr>
             <td>vehicleData</td>
             <td>retrieve all vehicle state data in a single call</td>
-            <td></td>
+            <td>endpoints, let_sleep</td>
         </tr>
         <tr>
             <td>chargeState</td>

--- a/src/tesla.html
+++ b/src/tesla.html
@@ -488,7 +488,7 @@
         <tr>
             <td>windowControl</td>
             <td>windowControl</td>
-            <td>command</td>
+            <td>command, lat, lon</td>
         </tr>
         <tr>
             <td>vinDecode</td>

--- a/src/tesla.html
+++ b/src/tesla.html
@@ -386,7 +386,7 @@
         <tr>
             <td>remoteStart</td>
             <td>remoteStart</td>
-            <td>password</td>
+            <td></td>
         </tr>
         <tr>
             <td>resetValetPin</td>

--- a/src/tesla.html
+++ b/src/tesla.html
@@ -98,6 +98,10 @@
         <label for="node-input-command" style="white-space: nowrap; width: 125px"><i class="icon-tag"></i> Command</label>
         <select id="node-input-command" style="width: 70%">
             <option value="">&lt;msg.command&gt;</option>
+            <option value="get">get - Low level GET request</option>
+            <option value="post">post - Low level POST request</option>
+            <option value="vehicleGet">vehicleGet - Low level vehicle GET request</option>
+            <option value="vehiclePost">vehiclePost - Low level vehicle POST request</option>
             <option value="vehicles">vehicles - A list of all vehicles available in your account</option>
             <option value="vehicle">vehicle - retrieve general vehicle information</option>
             <option value="vehicleData">vehicleData - retrieve all vehicle state data in a single call</option>
@@ -218,6 +222,26 @@
         </tr>
         </thead>
         <tbody>
+        <tr>
+            <td>get</td>
+            <td>Low level GET request</td>
+            <td>service, qs</td>
+        </tr>
+        <tr>
+            <td>post</td>
+            <td>Low level POST request</td>
+            <td>service, qs, body</td>
+        </tr>
+        <tr>
+            <td>vehicleGet</td>
+            <td>Low level vehicle GET request</td>
+            <td>command, qs</td>
+        </tr>
+        <tr>
+            <td>vehiclePost</td>
+            <td>Low level vehicle POST request</td>
+            <td>command, qs, body</td>
+        </tr>
         <tr>
             <td>vehicles</td>
             <td>A list of all vehicles available in your account</td>

--- a/src/tesla.html
+++ b/src/tesla.html
@@ -77,6 +77,7 @@
             <option value="doorUnlock">doorUnlock</option>
             <option value="climateStart">climateStart</option>
             <option value="climateStop">climateStop</option>
+            <option value="closeChargePort">closeChargePort</option>
             <option value="flashLights">flashLights</option>
             <option value="honkHorn">honkHorn</option>
             <option value="maxDefrost">maxDefrost</option>
@@ -158,6 +159,7 @@
             <tr><td>doorUnlock</td><td>doorUnlock</td><td></td></tr>
             <tr><td>climateStart</td><td>climateStart</td><td></td></tr>
             <tr><td>climateStop</td><td>climateStop</td><td></td></tr>
+            <tr><td>closeChargePort</td><td>closeChargePort</td><td></td></tr>
             <tr><td>flashLights</td><td>flashLights</td><td></td></tr>
             <tr><td>honkHorn</td><td>honkHorn</td><td></td></tr>
             <tr><td>maxDefrost</td><td>maxDefrost</td><td>onoff</td></tr>
@@ -194,7 +196,7 @@
             <tr><td>stopCharge</td><td>stopCharge</td><td></td></tr>
             <tr><td>sunRoofControl</td><td>sunRoofControl</td><td>state</td></tr>
             <tr><td>sunRoofMove</td><td>sunRoofMove</td><td>percent</td></tr>
-            <tr><td>windowControl</td><td>windowControl</td><td>command</td></tr>
+            <tr><td>windowControl</td><td>windowControl</td><td>command, lat, lon</td></tr>
             <tr><td>vinDecode</td><td>vinDecode</td><td></td></tr>
             <tr><td>getModel</td><td>getModel</td><td></td></tr>
             <tr><td>getPaintColor</td><td>getPaintColor</td><td></td></tr>

--- a/src/tesla.html
+++ b/src/tesla.html
@@ -39,8 +39,12 @@
             $("#node-input-lookup-vehicles-icon").addClass('fa-search');
             $("#node-input-lookup-vehicles-icon").removeClass('spinner');
             $("#node-input-lookup-vehicles").removeClass('disabled');
-            let vehicles = data || [];
+            let vehicles = data ?? [];
             $('#node-input-vehicleID').empty();
+            $('#node-input-vehicleID').append($('<option>', {
+                value: "",
+                text: "<msg.vehicleID>"
+            }));
             $.each(vehicles, function (i, item) {
                 $('#node-input-vehicleID').append($('<option>', {
                     value: item.id,
@@ -65,7 +69,7 @@
         outputs: 1,
         icon: "tesla.png",
         label: function () {
-            return this.name || "Tesla API";
+            return this.name ?? "Tesla API";
         },
         oneditprepare: function () {
             var node = this;
@@ -93,6 +97,7 @@
     <div class="form-row">
         <label for="node-input-command" style="white-space: nowrap; width: 125px"><i class="icon-tag"></i> Command</label>
         <select id="node-input-command" style="width: 70%">
+            <option value="">&lt;msg.command&gt;</option>
             <option value="vehicles">vehicles - A list of all vehicles available in your account</option>
             <option value="vehicle">vehicle - retrieve general vehicle information</option>
             <option value="vehicleData">vehicleData - retrieve all vehicle state data in a single call</option>
@@ -153,7 +158,7 @@
         </select>
     </div>
     <div class="form-tips"><b>Tip:</b> You can also send msg.command to set the command. If msg.command is set, it will overwrite any choice set
-        below.</div>
+        above.</div>
 
     <div class="form-row" style="margin-top: 20px;">
         <label for="node-input-vehicleID" style="white-space: nowrap; width: 125px">Vehicle or Device</label>
@@ -168,7 +173,11 @@
 
     </div>
     <div class="form-tips">
-        <p>This node must be deployed first before you can get a list of vehicles.</p>
+        <p>This node must be deployed first before you can get a list of vehicles.
+        <br/>The vehicleID cannot be selected in a subflow, you have to set msg.vehicleID then (use 'vehicles' command which does not require this
+            data to get the list of valid vehicleID for this account).</p>
+        <b>Tip:</b> You can also send msg.vehicleID to set the vehicleID. If msg.vehicleID is set, it will overwrite any choice set
+        above.
     </div>
     <div style="margin-top: 20px;">
         <label for="node-input-autoWakeUp">

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -186,7 +186,7 @@ module.exports = function (RED) {
             case 'sunRoofMove':
                 return tjs.sunRoofMoveAsync({authToken, vehicleID}, commandArgs.percent);
             case 'windowControl':
-                return tjs.windowControlAsync({authToken, vehicleID}, commandArgs.command);
+                return tjs.windowControlAsync({authToken, vehicleID}, commandArgs.command, commandArgs.lat, commandArgs.lon);
             case 'vinDecode':
                 return tjs.vinDecode(await tjs.vehicleAsync({authToken, vehicleID}));
             case 'getModel':

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -91,10 +91,7 @@ module.exports = function (RED) {
             case 'vehicle':
                 return tjs.vehicleAsync({authToken, vehicleID}, commandArgs);
             case 'vehicleData':
-                return tjs.vehicleDataAsync({
-                    authToken,
-                    vehicleID
-                }, commandArgs);
+                return tjs.vehicleDataAsync({authToken, vehicleID}, commandArgs);
             case 'chargeState':
                 return tjs.chargeStateAsync({authToken, vehicleID}, commandArgs);
             case 'climateState':
@@ -144,14 +141,13 @@ module.exports = function (RED) {
             case 'mobileEnabled':
                 return tjs.mobileEnabledAsync({authToken, vehicleID}, commandArgs);
             case 'navigationRequest':
-                return tjs.navigationRequestAsync({
-                    authToken,
-                    vehicleID
-                }, commandArgs);
+                return tjs.navigationRequestAsync({authToken, vehicleID}, commandArgs);
             case 'nearbyChargers':
                 return tjs.nearbyChargersAsync({authToken, vehicleID}, commandArgs);
             case 'openChargePort':
                 return tjs.openChargePortAsync({authToken, vehicleID}, commandArgs);
+            case 'closeChargePort':
+                return tjs.closeChargePortAsync({authToken, vehicleID}, commandArgs);
             case 'openFrunk':
                 return tjs.openTrunkAsync({authToken, vehicleID}, { which: "front" });
             case 'openTrunk':
@@ -171,10 +167,7 @@ module.exports = function (RED) {
             case 'setScheduledCharging':
                 return tjs.setScheduledChargingAsync({authToken, vehicleID}, commandArgs);
             case 'setScheduledDeparture':
-                return tjs.setScheduledDepartureAsync({
-                    authToken,
-                    vehicleID
-                }, commandArgs);
+                return tjs.setScheduledDepartureAsync({authToken, vehicleID}, commandArgs);
             case 'setSentryMode':
                 return tjs.setSentryModeAsync({authToken, vehicleID}, commandArgs);
             case 'setTemps':

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -88,6 +88,7 @@ module.exports = function (RED) {
             case 'navigationRequest': return tjs.navigationRequestAsync({authToken, vehicleID}, commandArgs.subject, commandArgs.text, commandArgs.locale);
             case 'nearbyChargers': return tjs.nearbyChargersAsync({authToken, vehicleID});
             case 'openChargePort': return tjs.openChargePortAsync({authToken, vehicleID});
+            case 'closeChargePort': return tjs.closeChargePortAsync({authToken, vehicleID});
             case 'openFrunk': return tjs.openTrunkAsync({authToken, vehicleID}, "frunk");
             case 'openTrunk': return tjs.openTrunkAsync({authToken, vehicleID}, "trunk");
             case 'remoteStart': return tjs.remoteStartAsync({authToken, vehicleID}, commandArgs.password);
@@ -110,7 +111,7 @@ module.exports = function (RED) {
             case 'stopCharge': return tjs.stopChargeAsync({authToken, vehicleID});
             case 'sunRoofControl': return tjs.sunRoofControlAsync({authToken, vehicleID}, commandArgs.state);
             case 'sunRoofMove': return tjs.sunRoofMoveAsync({authToken, vehicleID}, commandArgs.percent);
-            case 'windowControl': return tjs.windowControlAsync({authToken, vehicleID}, commandArgs.command);
+            case 'windowControl': return tjs.windowControlAsync({authToken, vehicleID}, commandArgs.command, commandArgs.lat, commandArgs.lon);
             case 'vinDecode': return tjs.vinDecode(await tjs.vehicleAsync({authToken, vehicleID}));
             case 'getModel': return tjs.getModel(await tjs.vehicleAsync({authToken, vehicleID}));
             case 'getPaintColor': return tjs.getPaintColor(await tjs.vehicleAsync({authToken, vehicleID}));
@@ -157,13 +158,13 @@ module.exports = function (RED) {
                     node.send.apply(node, arguments)
                 };
                 const {vehicleID} = node.teslaConfig;
-                const command = msg.command || config.command;
+                const command = msg.command ?? config.command;
 
                 // TODO: Remove manual token when auth flow is fixed in TeslaJs
                 const {email, password, manualToken} = node.teslaConfig.credentials;
                 const { commandArgs } = msg;
                 if (command === 'remoteStart') {
-                    commandArgs.password = password;
+                    commandArgs.password = commandArgs.password ?? password;
                 }
 
                 try {

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -77,6 +77,17 @@ module.exports = function (RED) {
         }
 
         switch (command) {
+            // Low level access
+            case 'get':
+                return tjs.getAsync({authToken, vehicleID}, commandArgs?.service, commandArgs?.qs);
+            case 'post':
+                return tjs.postAsync({authToken, vehicleID}, commandArgs?.service, commandArgs?.qs, commandArgs?.body);
+            case 'vehicleGet':
+                return tjs.get_commandAsync({authToken, vehicleID}, commandArgs?.command, commandArgs?.qs);
+            case 'vehiclePost':
+                return tjs.post_commandAsync({authToken, vehicleID}, commandArgs?.command, commandArgs?.qs, commandArgs?.body);
+
+            // High level commands
             case 'vehicle':
                 return tjs.vehicleAsync({authToken, vehicleID}, commandArgs);
             case 'vehicleData':

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -76,7 +76,7 @@ module.exports = function (RED) {
             case 'climateStop': return tjs.climateStopAsync({authToken, vehicleID});
             case 'flashLights': return tjs.flashLightsAsync({authToken, vehicleID});
             case 'honkHorn': return tjs.honkHornAsync({authToken, vehicleID});
-            case 'maxDefrost': return tjs.maxDefrostAsync({authToken, vehicleID});
+            case 'maxDefrost': return tjs.maxDefrostAsync({authToken, vehicleID}, commandArgs.onoff);
             case 'mediaTogglePlayback': return tjs.mediaTogglePlaybackAsync({authToken, vehicleID});
             case 'mediaPlayNext': return tjs.mediaPlayNextAsync({authToken, vehicleID});
             case 'mediaPlayPrevious': return tjs.mediaPlayPreviousAsync({authToken, vehicleID});

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -1,7 +1,7 @@
 module.exports = function (RED) {
 
     const crypto = require('crypto');
-    const tjs = require('teslajs');
+    const tjs = require('@gaphi/teslajs');
 
     var localUserCache = {};
 

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -53,12 +53,12 @@ module.exports = function (RED) {
     const wakeUp = async (authToken, vehicleID, retry = 0) => {
         let state;
         if (!retry) {
-            const vehicleData = await tjs.vehicleAsync({authToken, vehicleID}, null, false);
+            const vehicleData = await tjs.vehicleAsync({authToken, vehicleID}, null);
             state = vehicleData.state;
         }
         if (retry > 0 || state === STATE_ASLEEP) {
             console.debug('Tesla API: trying to wakeup the car. retry: ' + retry);
-            const response = await tjs.wakeUpAsync({authToken, vehicleID});
+            const response = await tjs.wakeUpAsync({authToken, vehicleID}, null);
             if (response.state === STATE_ASLEEP) {
                 await new Promise((resolve => setTimeout(() => resolve(), 5000)));
                 retry++;
@@ -78,124 +78,124 @@ module.exports = function (RED) {
 
         switch (command) {
             case 'vehicle':
-                return tjs.vehicleAsync({authToken, vehicleID});
+                return tjs.vehicleAsync({authToken, vehicleID}, commandArgs);
             case 'vehicleData':
                 return tjs.vehicleDataAsync({
                     authToken,
                     vehicleID
-                }, commandArgs.endpoints, commandArgs.let_sleep);
+                }, commandArgs);
             case 'chargeState':
-                return tjs.chargeStateAsync({authToken, vehicleID});
+                return tjs.chargeStateAsync({authToken, vehicleID}, commandArgs);
             case 'climateState':
-                return tjs.climateStateAsync({authToken, vehicleID});
+                return tjs.climateStateAsync({authToken, vehicleID}, commandArgs);
             case 'vehicleConfig':
-                return tjs.vehicleConfigAsync({authToken, vehicleID});
+                return tjs.vehicleConfigAsync({authToken, vehicleID}, commandArgs);
             case 'vehicleState':
-                return tjs.vehicleStateAsync({authToken, vehicleID});
+                return tjs.vehicleStateAsync({authToken, vehicleID}, commandArgs);
             case 'driveState':
-                return tjs.driveStateAsync({authToken, vehicleID});
+                return tjs.driveStateAsync({authToken, vehicleID}, commandArgs);
             case 'guiSettings':
-                return tjs.guiSettingsAsync({authToken, vehicleID});
+                return tjs.guiSettingsAsync({authToken, vehicleID}, commandArgs);
             case 'wakeUp':
-                return tjs.wakeUpAsync({authToken, vehicleID});
+                return tjs.wakeUpAsync({authToken, vehicleID}, commandArgs);
             case 'chargeStandard':
-                return tjs.chargeStandardAsync({authToken, vehicleID});
+                return tjs.chargeStandardAsync({authToken, vehicleID}, commandArgs);
             case 'chargeMaxRange':
-                return tjs.chargeMaxRangeAsync({authToken, vehicleID});
+                return tjs.chargeMaxRangeAsync({authToken, vehicleID}, commandArgs);
             case 'doorLock':
-                return tjs.doorLockAsync({authToken, vehicleID});
+                return tjs.doorLockAsync({authToken, vehicleID}, commandArgs);
             case 'doorUnlock':
-                return tjs.doorUnlockAsync({authToken, vehicleID});
+                return tjs.doorUnlockAsync({authToken, vehicleID}, commandArgs);
             case 'climateStart':
-                return tjs.climateStartAsync({authToken, vehicleID});
+                return tjs.climateStartAsync({authToken, vehicleID}, commandArgs);
             case 'climateStop':
-                return tjs.climateStopAsync({authToken, vehicleID});
+                return tjs.climateStopAsync({authToken, vehicleID}, commandArgs);
             case 'flashLights':
-                return tjs.flashLightsAsync({authToken, vehicleID});
+                return tjs.flashLightsAsync({authToken, vehicleID}, commandArgs);
             case 'honkHorn':
-                return tjs.honkHornAsync({authToken, vehicleID});
+                return tjs.honkHornAsync({authToken, vehicleID}, commandArgs);
             case 'maxDefrost':
-                return tjs.maxDefrostAsync({authToken, vehicleID});
+                return tjs.maxDefrostAsync({authToken, vehicleID}, commandArgs);
             case 'mediaTogglePlayback':
-                return tjs.mediaTogglePlaybackAsync({authToken, vehicleID});
+                return tjs.mediaTogglePlaybackAsync({authToken, vehicleID}, commandArgs);
             case 'mediaPlayNext':
-                return tjs.mediaPlayNextAsync({authToken, vehicleID});
+                return tjs.mediaPlayNextAsync({authToken, vehicleID}, commandArgs);
             case 'mediaPlayPrevious':
-                return tjs.mediaPlayPreviousAsync({authToken, vehicleID});
+                return tjs.mediaPlayPreviousAsync({authToken, vehicleID}, commandArgs);
             case 'mediaPlayNextFavorite':
-                return tjs.mediaPlayNextFavoriteAsync({authToken, vehicleID});
+                return tjs.mediaPlayNextFavoriteAsync({authToken, vehicleID}, commandArgs);
             case 'mediaPlayPreviousFavorite':
-                return tjs.mediaPlayPreviousFavoriteAsync({authToken, vehicleID});
+                return tjs.mediaPlayPreviousFavoriteAsync({authToken, vehicleID}, commandArgs);
             case 'mediaVolumeUp':
-                return tjs.mediaVolumeUpAsync({authToken, vehicleID});
+                return tjs.mediaVolumeUpAsync({authToken, vehicleID}, commandArgs);
             case 'mediaVolumeDown':
-                return tjs.mediaVolumeDownAsync({authToken, vehicleID});
+                return tjs.mediaVolumeDownAsync({authToken, vehicleID}, commandArgs);
             case 'mobileEnabled':
-                return tjs.mobileEnabledAsync({authToken, vehicleID});
+                return tjs.mobileEnabledAsync({authToken, vehicleID}, commandArgs);
             case 'navigationRequest':
                 return tjs.navigationRequestAsync({
                     authToken,
                     vehicleID
-                }, commandArgs.subject, commandArgs.text, commandArgs.locale);
+                }, commandArgs);
             case 'nearbyChargers':
-                return tjs.nearbyChargersAsync({authToken, vehicleID});
+                return tjs.nearbyChargersAsync({authToken, vehicleID}, commandArgs);
             case 'openChargePort':
-                return tjs.openChargePortAsync({authToken, vehicleID});
+                return tjs.openChargePortAsync({authToken, vehicleID}, commandArgs);
             case 'openFrunk':
-                return tjs.openTrunkAsync({authToken, vehicleID}, "frunk");
+                return tjs.openTrunkAsync({authToken, vehicleID}, { which: "frunk" });
             case 'openTrunk':
-                return tjs.openTrunkAsync({authToken, vehicleID}, "trunk");
+                return tjs.openTrunkAsync({authToken, vehicleID}, { which: "trunk" });
             case 'remoteStart':
-                return tjs.remoteStartAsync({authToken, vehicleID});
+                return tjs.remoteStartAsync({authToken, vehicleID}, commandArgs);
             case 'resetValetPin':
-                return tjs.resetValetPinAsync({authToken, vehicleID});
+                return tjs.resetValetPinAsync({authToken, vehicleID}, commandArgs);
             case 'scheduleSoftwareUpdate':
-                return tjs.scheduleSoftwareUpdateAsync({authToken, vehicleID}, commandArgs.offset);
+                return tjs.scheduleSoftwareUpdateAsync({authToken, vehicleID}, commandArgs);
             case 'seatHeater':
-                return tjs.seatHeaterAsync({authToken, vehicleID}, commandArgs.heater, commandArgs.level);
+                return tjs.seatHeaterAsync({authToken, vehicleID}, commandArgs);
             case 'setChargeLimit':
-                return tjs.setChargeLimitAsync({authToken, vehicleID}, commandArgs.amt);
+                return tjs.setChargeLimitAsync({authToken, vehicleID}, commandArgs);
             case 'setChargingAmps':
-                return tjs.setChargingAmpsAsync({authToken, vehicleID}, commandArgs.amps);
+                return tjs.setChargingAmpsAsync({authToken, vehicleID}, commandArgs);
             case 'setScheduledCharging':
-                return tjs.setScheduledChargingAsync({authToken, vehicleID}, commandArgs.enable, commandArgs.time);
+                return tjs.setScheduledChargingAsync({authToken, vehicleID}, commandArgs);
             case 'setScheduledDeparture':
                 return tjs.setScheduledDepartureAsync({
                     authToken,
                     vehicleID
-                }, commandArgs.enable, commandArgs.departure_time, commandArgs.preconditioning_enabled, commandArgs.preconditioning_weekdays_only, commandArgs.off_peak_charging_enabled, commandArgs.off_peak_charging_weekdays_only, commandArgs.end_off_peak_time);
+                }, commandArgs);
             case 'setSentryMode':
-                return tjs.setSentryModeAsync({authToken, vehicleID}, commandArgs.onoff);
+                return tjs.setSentryModeAsync({authToken, vehicleID}, commandArgs);
             case 'setTemps':
-                return tjs.setTempsAsync({authToken, vehicleID}, commandArgs.driver, commandArgs.pass);
+                return tjs.setTempsAsync({authToken, vehicleID}, commandArgs);
             case 'setValetMode':
-                return tjs.setValetModeAsync({authToken, vehicleID}, commandArgs.onoff, commandArgs.pin);
+                return tjs.setValetModeAsync({authToken, vehicleID}, commandArgs);
             case 'speedLimitActivate':
-                return tjs.speedLimitActivateAsync({authToken, vehicleID}, commandArgs.pin);
+                return tjs.speedLimitActivateAsync({authToken, vehicleID}, commandArgs);
             case 'speedLimitDeactivate':
-                return tjs.speedLimitDeactivateAsync({authToken, vehicleID}, commandArgs.pin);
+                return tjs.speedLimitDeactivateAsync({authToken, vehicleID}, commandArgs);
             case 'speedLimitClearPin':
-                return tjs.speedLimitClearPinAsync({authToken, vehicleID}, commandArgs.pin);
+                return tjs.speedLimitClearPinAsync({authToken, vehicleID}, commandArgs);
             case 'speedLimitSetLimit':
-                return tjs.speedLimitSetLimitAsync({authToken, vehicleID}, commandArgs.limit);
+                return tjs.speedLimitSetLimitAsync({authToken, vehicleID}, commandArgs);
             case 'startCharge':
-                return tjs.startChargeAsync({authToken, vehicleID});
+                return tjs.startChargeAsync({authToken, vehicleID}, commandArgs);
             case 'steeringHeater':
-                return tjs.steeringHeaterAsync({authToken, vehicleID}, commandArgs.level);
+                return tjs.steeringHeaterAsync({authToken, vehicleID}, commandArgs);
             case 'stopCharge':
-                return tjs.stopChargeAsync({authToken, vehicleID});
+                return tjs.stopChargeAsync({authToken, vehicleID}, commandArgs);
             case 'sunRoofControl':
-                return tjs.sunRoofControlAsync({authToken, vehicleID}, commandArgs.state);
+                return tjs.sunRoofControlAsync({authToken, vehicleID}, commandArgs);
             case 'sunRoofMove':
-                return tjs.sunRoofMoveAsync({authToken, vehicleID}, commandArgs.percent);
+                return tjs.sunRoofMoveAsync({authToken, vehicleID}, commandArgs);
             case 'windowControl':
-                return tjs.windowControlAsync({authToken, vehicleID}, commandArgs.command, commandArgs.lat, commandArgs.lon);
+                return tjs.windowControlAsync({authToken, vehicleID}, commandArgs);
             case 'vinDecode':
-                return tjs.vinDecode(await tjs.vehicleAsync({authToken, vehicleID}));
+                return tjs.vinDecode(await tjs.vehicleAsync({authToken, vehicleID}, commandArgs));
             case 'getModel':
-                return tjs.getModel(await tjs.vehicleAsync({authToken, vehicleID}));
+                return tjs.getModel(await tjs.vehicleAsync({authToken, vehicleID}, commandArgs));
             case 'getPaintColor':
-                return tjs.getPaintColor(await tjs.vehicleAsync({authToken, vehicleID}));
+                return tjs.getPaintColor(await tjs.vehicleAsync({authToken, vehicleID}, commandArgs));
 
             default:
                 throw Error(`Tesla API: Invalid command specified: ${command}`);
@@ -243,7 +243,7 @@ module.exports = function (RED) {
                     node.status({fill: "blue", shape: "dot", text: "Working"});
                     const authToken = await getAccessToken(email, refresh_token);
                     if (command === 'vehicles') {
-                        msg.payload = await tjs.vehiclesAsync({authToken});
+                        msg.payload = await tjs.vehiclesAsync({authToken}, null);
                     } else {
                         msg.payload = await doCommandAndAutoWake(command, authToken, vehicleID, autoWakeUp, commandArgs);
                     }
@@ -283,7 +283,7 @@ module.exports = function (RED) {
 
         if (email && refresh_token) {
             const authToken = await getAccessToken(email, refresh_token);
-            const response = await tjs.vehiclesAsync({authToken});
+            const response = await tjs.vehiclesAsync({authToken}, null);
             if (response.length) {
                 res.json(response.map(item => {
                     const vehicleId = item.id_s;

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -153,9 +153,9 @@ module.exports = function (RED) {
             case 'openChargePort':
                 return tjs.openChargePortAsync({authToken, vehicleID}, commandArgs);
             case 'openFrunk':
-                return tjs.openTrunkAsync({authToken, vehicleID}, { which: "frunk" });
+                return tjs.openTrunkAsync({authToken, vehicleID}, { which: "front" });
             case 'openTrunk':
-                return tjs.openTrunkAsync({authToken, vehicleID}, { which: "trunk" });
+                return tjs.openTrunkAsync({authToken, vehicleID}, { which: "rear" });
             case 'remoteStart':
                 return tjs.remoteStartAsync({authToken, vehicleID}, commandArgs);
             case 'resetValetPin':

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -143,7 +143,7 @@ module.exports = function (RED) {
             case 'openTrunk':
                 return tjs.openTrunkAsync({authToken, vehicleID}, "trunk");
             case 'remoteStart':
-                return tjs.remoteStartAsync({authToken, vehicleID}, commandArgs.password);
+                return tjs.remoteStartAsync({authToken, vehicleID});
             case 'resetValetPin':
                 return tjs.resetValetPinAsync({authToken, vehicleID});
             case 'scheduleSoftwareUpdate':

--- a/src/tesla.js
+++ b/src/tesla.js
@@ -53,7 +53,7 @@ module.exports = function (RED) {
     const wakeUp = async (authToken, vehicleID, retry = 0) => {
         let state;
         if (!retry) {
-            const vehicleData = await tjs.vehicleAsync({authToken, vehicleID});
+            const vehicleData = await tjs.vehicleAsync({authToken, vehicleID}, null, false);
             state = vehicleData.state;
         }
         if (retry > 0 || state === STATE_ASLEEP) {
@@ -80,7 +80,10 @@ module.exports = function (RED) {
             case 'vehicle':
                 return tjs.vehicleAsync({authToken, vehicleID});
             case 'vehicleData':
-                return tjs.vehicleDataAsync({authToken, vehicleID});
+                return tjs.vehicleDataAsync({
+                    authToken,
+                    vehicleID
+                }, commandArgs.endpoints, commandArgs.let_sleep);
             case 'chargeState':
                 return tjs.chargeStateAsync({authToken, vehicleID});
             case 'climateState':


### PR DESCRIPTION
Let query vehicle with vehicleData without avoiding it to fall asleep

Requires an updated teslajs library (gaphi/teslajs 4.10.1-2 as a minimum)