### PR TITLE
corrected steering wheel commandArg

### DIFF
--- a/src/tesla.js
+++ b/src/tesla.js
@@ -178,7 +178,7 @@ module.exports = function (RED) {
             case 'startCharge':
                 return tjs.startChargeAsync({authToken, vehicleID});
             case 'steeringHeater':
-                return tjs.steeringHeaterAsync({authToken, vehicleID}, commandArgs.level);
+                return tjs.steeringHeaterAsync({authToken, vehicleID}, commandArgs.on);
             case 'stopCharge':
                 return tjs.stopChargeAsync({authToken, vehicleID});
             case 'sunRoofControl':


### PR DESCRIPTION
According to https://tesla-api.timdorr.com/vehicle/commands/climate#post-api-1-vehicles-id-command-remote_steering_wheel_heater_request the argument should be "on" and not "level" it was really a pain to find the issue, why my steering wheel won't turn on.